### PR TITLE
fix: mypy strict mode for prompt session

### DIFF
--- a/pyastrx/frontend/state_machine.py
+++ b/pyastrx/frontend/state_machine.py
@@ -34,9 +34,9 @@ from pyastrx.xml.misc import el_lxml2str
 #  prompt dialog auto suggest history
 if not Path(".pyastrx").exists():
     Path(".pyastrx").mkdir()
-_PromptSessionExpr: PromptSession = PromptSession(
+_PromptSessionExpr: PromptSession[str] = PromptSession(
     history=FileHistory('.pyastrx/history_new_expr.txt'))
-_PromptSessionRules: PromptSession = PromptSession(
+_PromptSessionRules: PromptSession[str] = PromptSession(
     history=FileHistory('.pyastrx/history_rules.txt'))
 
 


### PR DESCRIPTION
Solution given by @jonathanslenders

Related to the following issue
https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1638