### PR TITLE
fix cache files for yaml/py files with same filename

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,25 @@
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: ".md$"
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
-    hooks:
-    - id: flake8
   - repo: local
+    hooks:
+      - id: pyastrx
+        name: PyASTrX linter
+        entry: ./.pre-commit-hook/main.py
+        language: script
+        args: ["-q"]
+        types: ["python"]
+        description: Check for any violations using the pyastrx.yaml config
+      - id: pyastrx-yaml
+        name: PyASTrX linter
+        entry: ./.pre-commit-hook/main.py
+
+        language: script
+        args: ["-q"]
+        types: ["yaml"]
+        description: Check for any violations using the pyastrx.yaml config
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict
         name: check for merge conflicts

--- a/.pre-commit-hook/main.py
+++ b/.pre-commit-hook/main.py
@@ -8,7 +8,9 @@ import sys
 
 if __name__ == "__main__":
     files = [
-        f for f in sys.argv if f.endswith(".py")
+        f for f in sys.argv if any(
+            [f.endswith(f".{ext}") for ext in ("yaml", "yml", "py")]
+        )
     ]
     if len(files) == 0:
         print("No files to check")
@@ -18,7 +20,7 @@ if __name__ == "__main__":
         commands.append("-q")
     process = subprocess.Popen(
         commands,
-        shell=False
+        shell=True
     )
     process.communicate()
     exit_code = process.wait()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ## [Unreleased]
+
+## [0.5.2] - 2023-10-01
+
+
+### Fixed
+
+- cache files are now stored with the original file extension followed by `.cache`. This fixes the issue
+with two files with the same name but different extensions.
+
+- Now it's possible to pass a list of different files mixing python and YAML files withouth any problem.
+
 ## [0.5.1] - 2023-08-01
 
 ### Fixed
@@ -114,7 +125,8 @@ $ mypyq filename.py
 
 ### Changed
 
-[Unreleased]: https://github.com/pyastrx/pyastrx/compare/0.5.1...main
+[Unreleased]: https://github.com/pyastrx/pyastrx/compare/0.5.2...main
+[0.5.2]: https://github.com/pyastrx/pyastrx/compare/0.5.2...0.5.1
 [0.5.1]: https://github.com/pyastrx/pyastrx/compare/0.5.1...0.5.0
 [0.5.0]: https://github.com/pyastrx/pyastrx/compare/0.5.0...0.4.3
 [0.4.3]: https://github.com/pyastrx/pyastrx/compare/0.4.3...0.4.2

--- a/docs/source/index_content.rst
+++ b/docs/source/index_content.rst
@@ -103,7 +103,13 @@ in your folder and add the following entry in your `.pre-commit-config.yaml`.
             args: ["-q"]
             types: ["python"]
             description: Check for any violations using the pyastrx.yaml config
-
+        - id: pyastrx-yaml
+            name: PyASTrX linter
+            entry: ./<LOCATION>/main.py
+            language: script
+            args: ["-q"]
+            types: ["yaml"]
+            description: Check for any violations YAML using the pyastrx.yaml config
 
 Later on, I will ship this to be used in the pre-commit channels.
 

--- a/pyastrx.yaml
+++ b/pyastrx.yaml
@@ -1,11 +1,50 @@
 after_context: 3
-before_context: 3
+before_context: true
 interactive_files: false
 pagination: true
 quiet: false
-vscode_output: true
 parallel: true
 specifications:
+  pyastrx:
+    language: yaml
+    files: [pyastrx.yaml]
+    rules:
+      after_context:
+        xpath:
+          |
+          /Module/KeyNode[@name="after_context"]
+          /*[
+            not(self::IntNode)
+          ]
+        description: "after_context should be a int"
+        severity: error
+      before_context:
+        xpath:
+          |
+          /Module/KeyNode[@name="before_context"]
+          /*[
+            not(self::IntNode)
+          ]
+        description: "before_context should be a int"
+        severity: error
+      interactive_files:
+        xpath:
+          |
+          /Module/KeyNode[@name="interactive_files"]
+          /*[
+            not(self::BoolNode)
+          ]
+        description: "interactive_files should be a boolean"
+        severity: error
+      pagination:
+        xpath:
+          |
+          /Module/KeyNode[@name="pagination"]
+          /*[
+            not(self::BoolNode)
+          ]
+        description: "pagination should be a boolean"
+
   dbt:
     language: yaml
     parallel: true

--- a/pyastrx/__init__.py
+++ b/pyastrx/__init__.py
@@ -9,7 +9,7 @@ pylint
 from rich import print as rprint
 
 __pkg_name__ = "PyASTrX"
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 __author__ = 'Bruno Messias'
 __github_author__ = '@devmessias'
 __twitter__ = '@devmessias'

--- a/pyastrx/folder_utils.py
+++ b/pyastrx/folder_utils.py
@@ -15,9 +15,12 @@ def get_location_and_create(
     current_folder = Path(".").resolve()
     export_folder = Path(base_location).resolve()
     path_location = Path(filename).resolve()
-    filename = path_location.name.replace(".py", extension)
+    suffix = path_location.suffix
+    new_filename = path_location.name
     location = path_location.parent.relative_to(current_folder)
-    export_location = export_folder/location/filename
+    export_location = export_folder/location/new_filename
+    export_location = export_location.with_suffix(f"{suffix}{extension}")
+
     if not export_location.parent.exists():
         export_location.parent.mkdir(parents=True)
 

--- a/pyastrx/frontend/cli.py
+++ b/pyastrx/frontend/cli.py
@@ -244,7 +244,12 @@ def invoke_pyastrx(args: argparse.Namespace) -> None:
 
     for spec_name, spec in specs_dict.items():
         if "files" not in spec:
-            spec["files"] = args.file
+            spec_lang = spec["language"]
+            if spec_lang == "python":
+                files = [f for f in args.file if f.endswith(".py")]
+            elif spec_lang == "yaml":
+                files = [f for f in args.file if f.endswith(".yaml") or f.endswith(".yml")]  # noqa
+            spec["files"] = files
 
         for key, val in __available_yaml_folder.items():
             if key not in spec:

--- a/pyastrx/frontend/state_machine.py
+++ b/pyastrx/frontend/state_machine.py
@@ -520,7 +520,6 @@ class ExportXML(State):
             axml_str = el_lxml2str(axml)
             export_location = get_location_and_create(
                 ".pyastrx/export_data/axml/", filename, ".xml")
-
             with open(export_location, "w") as f:
                 f.write(axml_str)
         self.context.set_state(InterfaceMain)

--- a/pyastrx/search/cache.py
+++ b/pyastrx/search/cache.py
@@ -20,7 +20,8 @@ class Cache:
         root_folder = Path(".").absolute()
         file_cache = Path(
             f".pyastrx/files/{file_path.relative_to(root_folder)}").resolve()
-        file_cache = file_cache.with_suffix(".cache")
+        suffix = file_cache.suffix
+        file_cache = file_cache.with_suffix(f"{suffix}.cache")
         return file_cache
 
     def update(self, filename: str) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name='pyastrx',
-    version='0.5.1',
+    version='0.5.2',
     long_description=README_TEXT,
     long_description_content_type="text/x-rst",
     description="'Simple projects are all alike; each complex"\


### PR DESCRIPTION
## Fixed
- cache files are now stored with the original file extension followed by .cache. This fixes the issue with two files with the same name but with different extensions.

- Now it's possible to pass a list of different files mixing python and YAML files with no problem.